### PR TITLE
ready for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: java
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 MoonRise UI Theme
 =================
 
+[![Build Status](https://secure.travis-ci.org/guari/eclipse-ui-theme.png)](http://travis-ci.org/guari/eclipse-ui-theme)
 [![Flattr this git repo](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=guari&url=http://github.com/guari/eclipse-ui-theme&title=EclipseUITheme&language=&tags=github&category=software)
 
 An early version of a dark UI theme for Eclipse 4+.


### PR DESCRIPTION
### Travis CI

register on https://travis-ci.org

Setting up was straight-forward. As https://travis-ci.org/first_sync says:
- go to https://travis-ci.org/profile/guari

Please enable Travis, as there is build issue #29
