### PR TITLE
Added EditBox support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ You can find the one used in the screenshot below:
 
 **NOTE:** Syntax highlighting settings and UI theme are separated, you can import your own scheme or customize it in Eclipse Preferences if you like.
 
+**EditBox support:** Download [RainbowDrops.eb](https://github.com/guari/eclipse-ui-theme/blob/master/com.github.eclipseuitheme.themes.plugin/bin/color-scheme/RainbowDrops.eb?raw=true) (by right-clicking the link and selecting ```Save link as...```), then import it with the [Eclipse EditBox Plugin](http://editbox.sourceforge.net/).
+
 - - -
 ### Fine-tuning:
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can find the one used in the screenshot below:
 
 **NOTE:** Syntax highlighting settings and UI theme are separated, you can import your own scheme or customize it in Eclipse Preferences if you like.
 
-**EditBox support:** Download [RainbowDrops.eb](https://github.com/guari/eclipse-ui-theme/blob/master/com.github.eclipseuitheme.themes.plugin/bin/color-scheme/RainbowDrops.eb?raw=true) (by right-clicking the link and selecting ```Save link as...```), then import it with the [Eclipse EditBox Plugin](http://editbox.sourceforge.net/).
+**EditBox support:** Download [RainbowDrops.eb](https://github.com/guari/eclipse-ui-theme/blob/master/com.github.eclipseuitheme.themes.plugin/bin/color-scheme/RainbowDrops.eb?raw=true) (by right-clicking the link and selecting ```Save link as...```), then import the with the [Eclipse EditBox Plugin](http://editbox.sourceforge.net/).
 
 - - -
 ### Fine-tuning:

--- a/com.github.eclipseuitheme.themes.plugin/bin/color-scheme/RainbowDrops.eb
+++ b/com.github.eclipseuitheme.themes.plugin/bin/color-scheme/RainbowDrops.eb
@@ -1,0 +1,27 @@
+#Editbox Eclipse Plugin Settings
+#Made for the MoonRise UI Theme
+HighlightOne=true
+FillGradient=false
+FillSelected=false
+RoundBox=false
+BorderColorType=0
+Name=MoonRise
+ExpandBox=false
+BorderDrawLine=false
+FillOnMove=false
+Alpha=0
+HighlightWidth=1
+BorderWidth=1
+HighlightColor=00ff00
+BorderColor=00bbbb
+FillKeyModifier=Alt
+HighlightColorType=0
+FillGradientColor=null
+Builder=Java
+HighlightDrawLine=false
+FillSelectedColor=202020
+BorderLineStyle=1
+Colors=202020-null
+HighlightLineStyle=0
+NoBackground=false
+CirculateLevelColors=false


### PR DESCRIPTION
Added a scheme for the [Eclipse EditBox Plugin](http://editbox.sourceforge.net/) to support the RainbowDrops and MoonRise scheme.
It will look like this:

![](http://puu.sh/7BcnD/e1171fc0ee.png)
